### PR TITLE
Check_for_Addons_Updates: Added support for "Update Add-ons automatically"

### DIFF
--- a/Check_for_Addons_Updates/checkForAddonsUpdates.js
+++ b/Check_for_Addons_Updates/checkForAddonsUpdates.js
@@ -120,7 +120,7 @@ function processAddonsTab(e) {
 		if(!updEnabled)
 			cbu.setPrefs(updEnabledPref, false);
 
-		if(!notFound.hidden || !noneFound.hidden) {
+		if(!notFound.hidden) {
 			if(tab.collapsed)
 				gBrowser.removeTab(tab);
 			notify(notFound.getAttribute("value"));


### PR DESCRIPTION
Changes:
Added support for "Update Add-ons automatically" checkbox that would cause the script to loop (almost) indefinitely if checked.
Changed notification window's title to "Auto-Updater" instead of "Custom Buttons" (Seems to be a more appropriate title)
